### PR TITLE
Enhancements to tagging of repos

### DIFF
--- a/bin/repositorio
+++ b/bin/repositorio
@@ -53,7 +53,7 @@ GetOptions(
   "force-download",
   "list",      "add-file=s",      "remove-file=s", "init",
   "server",    "errata",          "update-errata", "package=s",
-  "version=s", "arch=s",          "clonetag=s"
+  "version=s", "arch=s",          "clonetag=s",    "force"
 );
 
 my $app = Rex::Repositorio->new( config => \%conf, logger => $logger );

--- a/bin/repositorio
+++ b/bin/repositorio
@@ -53,7 +53,7 @@ GetOptions(
   "force-download",
   "list",      "add-file=s",      "remove-file=s", "init",
   "server",    "errata",          "update-errata", "package=s",
-  "version=s", "arch=s",
+  "version=s", "arch=s",          "clonetag=s"
 );
 
 my $app = Rex::Repositorio->new( config => \%conf, logger => $logger );
@@ -95,6 +95,8 @@ create consistant installations of your server.
 =item --mirror            mirror a configured repository (needs --repo)
 
 =item --tag=tagname       tag a repository (needs --repo)
+
+=item --clonetag=tagname  clones a tag in a repository (needs --repo and new  --tag)
 
 =item --repo=reponame     the name of the repository to use
 

--- a/lib/Rex/Repositorio.pm
+++ b/lib/Rex/Repositorio.pm
@@ -421,8 +421,8 @@ sub tag {
   my $root_dir    = $self->config->{RepositoryRoot};
   $repo_config->{local} =~ s/\/$//;
 
-  my @dirs    = ( File::Spec->catpath(undef, $root_dir, $option{clonetag}, $repo_config->{local}) );
-  my $tag_dir = File::Spec->catpath(undef, $root_dir, $option{tag}, $repo_config->{local});
+  my @dirs    = ( File::Spec->catdir($root_dir, $option{clonetag}, $repo_config->{local}) );
+  my $tag_dir = File::Spec->catdir($root_dir, $option{tag}, $repo_config->{local});
 
   $self->logger->logcroak("Unknown tag $option{clonetag} on repo $option{repo} ($dirs[0])\n")
     unless ( -d $dirs[0] );

--- a/lib/Rex/Repositorio.pm
+++ b/lib/Rex/Repositorio.pm
@@ -94,7 +94,8 @@ sub parse_cli_option {
     $self->tag(
       tag => $option{tag},
       clonetag => $option{clonetag} || 'head',
-      repo => $option{repo}
+      repo => $option{repo},
+      force => $option{force} || 0,
     );
   }
 
@@ -410,6 +411,9 @@ sub tag {
       clonetag => {
         type => SCALAR
       },
+      force => {
+        type => BOOLEAN
+      }
     }
   );
 
@@ -417,32 +421,46 @@ sub tag {
   my $root_dir    = $self->config->{RepositoryRoot};
   $repo_config->{local} =~ s/\/$//;
 
-  my @dirs    = ("$root_dir/$option{clonetag}/$repo_config->{local}");
-  my $tag_dir = "$root_dir/$option{tag}/$repo_config->{local}";
+  my @dirs    = ( File::Spec->catpath(undef, $root_dir, $option{clonetag}, $repo_config->{local}) );
+  my $tag_dir = File::Spec->catpath(undef, $root_dir, $option{tag}, $repo_config->{local});
+
+  $self->logger->logcroak("Unknown tag $option{clonetag} on repo $option{repo} ($dirs[0])\n")
+    unless ( -d $dirs[0] );
+
+  if ( -e $tag_dir ) {
+    if( $option{force} ) {
+      $self->logger->debug("Removing $tag_dir");
+      rmtree $tag_dir; # should be remove_tree, but will use legacy to match mkdir
+    }
+    else {
+      $self->logger->logcroak("Tag $option{tag} on repo $option{repo} already exists ($tag_dir), use --force\n");
+    }
+  }
 
   mkpath $tag_dir;
 
   for my $dir (@dirs) {
     opendir my $dh, $dir
-        or $self->logger->logcroak("Unknown tag $option{clonetag} on repo $option{repo}\n");
+        or $self->logger->logcroak("Failed to open $dir: $!\nNew tag is probably unusable\n");
     while ( my $entry = readdir $dh ) {
       next if ( $entry eq "." || $entry eq ".." );
-      my $rel_entry = "$dir/$entry";
-      $rel_entry =~ s/$root_dir\/$option{clonetag}\/$repo_config->{local}\///;
+      my $rel_entry = File::Spec->catfile($dir, $entry);
+      $rel_entry =~ s{^$dirs[0]/}{}; # TODO use File::Spec
 
-      if ( -d "$dir/$entry" ) {
-        push @dirs, "$dir/$entry";
-        $self->logger->debug("Creating directory: $tag_dir/$rel_entry.");
-        mkdir "$tag_dir/$rel_entry";
+      my $srcfile = File::Spec->catfile($dir,$entry);
+      my $dstfile = File::Spec->catfile($tag_dir,$rel_entry);
+      $self->logger->debug("Tag Src: $srcfile, Dst: $dstfile");
+
+      if ( -d $srcfile ) {
+        push @dirs, $srcfile;
+        $self->logger->debug("Creating directory: $dstfile");
+        mkdir $dstfile;
         next;
       }
 
       $self->logger->debug(
-        "Linking (hard): $dir/$entry -> $tag_dir/$rel_entry");
-      if ( -f File::Spec->catfile( $tag_dir, $rel_entry ) ) {
-        unlink File::Spec->catfile( $tag_dir, $rel_entry );
-      }
-      link "$dir/$entry", "$tag_dir/$rel_entry";
+        "Linking (hard): $srcfile -> $dstfile");
+      link $srcfile, $dstfile;
     }
     closedir $dh;
   }

--- a/lib/Rex/Repositorio.pm
+++ b/lib/Rex/Repositorio.pm
@@ -630,12 +630,12 @@ create consistant installations of your server.
 To configure repositor.io create a configuration file
 I</etc/rex/repositorio.conf>.
  RepositoryRoot = /srv/html/repo/
-   
+
  # log4perl configuration file
  <Log4perl>
    config = /etc/rex/io/log4perl.conf
  </Log4perl>
-   
+
  # create a mirror of the nightly rex repository
  # the files will be stored in
  # /srv/html/repo/head/rex-centos-6-x86-64/CentOS/6/rex/x86_64/
@@ -644,7 +644,7 @@ I</etc/rex/repositorio.conf>.
    local = rex-centos-6-x86-64/CentOS/6/rex/x86_64/
    type  = Yum
  </Repository>
-   
+
  # create a mirror of centos 6
  # and download the pxe boot files, too.
  <Repository centos-6-x86-64>
@@ -653,13 +653,13 @@ I</etc/rex/repositorio.conf>.
    type   = Yum
    images = true
  </Repository>
-   
+
  # create a custom repository
  <Repository centos-6-x86-64-mixed>
    local = centos-6-x86-64-mixed/mixed/6/x86_64/
    type  = Yum
  </Repository>
-   
+
  <Repository debian-wheezy-i386-main>
    url       = http://ftp.de.debian.org/debian/
    local     = debian-wheezy-amd64-main/debian


### PR DESCRIPTION
As per the commit comments...

add --clonetag option, which allows an existing tag to be cloned (copied). Useful so that a 'testing' tag can be promoted to a 'production' tag.

add --force option to --tag, so that an existing tag is not over written unless you mean really it. 

use File::Spec throughout &tag, also check that the $dir opens and logcroak() if not.

removed some whitespace in POD

