### PR TITLE
Sub directory style tags, apache style config, some doc changes

### DIFF
--- a/bin/repositorio
+++ b/bin/repositorio
@@ -101,7 +101,7 @@ create consistant installations of your server.
 
 =over 4
 
-=item --mirror            mirror a configured repository (needs --repo)
+=item --mirror            mirror a configured repository (needs --repo, use "all" for all repos)
 
 =item --tag=tagname       tag a repository (needs --repo)
 

--- a/bin/repositorio
+++ b/bin/repositorio
@@ -30,7 +30,16 @@ if ( !$config_file ) {
     . join( ", ", @config_file_locations );
 }
 
-my $conf_o = Config::General->new($config_file);
+my $conf_o = Config::General->new(
+    -ConfigFile         => $config_file,
+    -UseApacheInclude   => 1,
+    -IncludeDirectories => 1,
+    -IncludeGlob        => 1,
+    -IncludeRelative    => 1,
+    -IncludeAgain       => 1,
+    -AllowMultiOptions  => 0,
+);
+
 my %conf   = $conf_o->getall;
 
 if ( !exists $conf{Log4perl} ) {

--- a/lib/Rex/Repositorio/Repository/OpenSuSE.pm
+++ b/lib/Rex/Repositorio/Repository/OpenSuSE.pm
@@ -93,12 +93,10 @@ sub mirror {
     my $path     = $file;
     my $repo_url = $self->repo->{url};
     $path =~ s/$repo_url//g;
-    my $local_path = File::Spec->catdir(
+    my $local_file = File::Spec->catdir(
       $self->app->get_repo_dir( repo => $self->repo->{name} ),
-      dirname($path) );
-    mkpath $local_path;
-
-    my $local_file = $self->repo->{local} . "/" . $path;
+      $path );
+    mkpath dirname($local_file);
 
     $self->download_package(
       url  => "$repo_url/$file",

--- a/lib/Rex/Repositorio/Repository/Plain.pm
+++ b/lib/Rex/Repositorio/Repository/Plain.pm
@@ -60,12 +60,10 @@ sub mirror {
     my $path     = $file;
     my $repo_url = $self->repo->{url};
     $path =~ s/$repo_url//g;
-    my $local_path = File::Spec->catdir(
+    my $local_file = File::Spec->catdir(
       $self->app->get_repo_dir( repo => $self->repo->{name} ),
-      dirname($path) );
-    mkpath $local_path;
-
-    my $local_file = $self->repo->{local} . "/" . $path;
+      $path );
+    mkpath basename($local_file);
 
     $self->download_package(
       url  => $file,
@@ -97,8 +95,8 @@ sub add_file {
     }
   );
 
-  my $dest = $self->app->get_repo_dir( repo => $self->repo->{name} ) . "/"
-    . basename( $option{file} );
+  my $dest = File::Spec->catdir($self->app->get_repo_dir( repo => $self->repo->{name} ),
+    basename( $option{file} ));
 
   $self->add_file_to_repo( source => $option{file}, dest => $dest );
 }
@@ -115,8 +113,8 @@ sub remove_file {
     }
   );
 
-  my $file = $self->app->get_repo_dir( repo => $self->repo->{name} ) . "/"
-    . basename( $option{file} );
+  my $file = File::Spec->catdir($self->app->get_repo_dir( repo => $self->repo->{name} ),
+     $option{file} );
 
   $self->remove_file_from_repo( file => $file );
 }

--- a/repositorio.conf
+++ b/repositorio.conf
@@ -3,6 +3,9 @@ RepositoryRoot = /var/www/repo/
 # how often a failed download should be retried.
 DownloadRetryCount = 3
 
+# Apache style includes:
+# include conf.d/*conf
+
 <Log4perl>
   config = log4perl.conf
 </Log4perl>

--- a/repositorio.conf
+++ b/repositorio.conf
@@ -3,6 +3,9 @@ RepositoryRoot = /var/www/repo/
 # how often a failed download should be retried.
 DownloadRetryCount = 3
 
+# specify repo tag style. either TopDir (default) or BottomDir
+TagStyle = BottomDir
+
 # Apache style includes:
 # include conf.d/*conf
 


### PR DESCRIPTION
This PR includes two fairly minor things and one quite large one.

Firstly, enable a bunch of options in Config::General around enabling the 'include' function. The updated selection of options allows the 'include' verb with directories and globs and allows config fragments to be loaded over and over. 

This permits for a parent repositorio.conf with something like repositorio.d/*conf to load in all the repo definitions. Handy for scripting and what not.

Secondly, the "all" keyword for repos is now documented and if found in the repositorio.conf you get a nasty error message.

Third, introduces a config option that places the tag directory at the bottom most directory rather than the top. There are pros and cons to top or bottom directory tags - which is briefly touched on in the commit message. Bottom directory style tags make much more sense for us. In the process, i also converted most path handling (if not all) to using File::Spec.

