### PR TITLE
dont try to mirror if there is no URL

### DIFF
--- a/lib/Rex/Repositorio/Repository/Yum.pm
+++ b/lib/Rex/Repositorio/Repository/Yum.pm
@@ -24,6 +24,11 @@ extends "Rex::Repositorio::Repository::Base";
 sub mirror {
   my ( $self, %option ) = @_;
 
+  unless ($self->repo->{url}) {
+    $self->app->logger->notice('No URL, skipping mirror');
+    return
+  }
+
   $self->repo->{url} =~ s/\/$//;
   $self->repo->{local} =~ s/\/$//;
   my $name = $self->repo->{name};


### PR DESCRIPTION
small adjustment, otherwise this command fails miserably (unless *every* repo has a URL... which is unlikely)

 repositorio --mirror --repos all