### PR TITLE
Fix #49 'mkdir File::Path: Permission denied' error

### DIFF
--- a/lib/Rex/Repositorio/Repository/Apt.pm
+++ b/lib/Rex/Repositorio/Repository/Apt.pm
@@ -13,6 +13,7 @@ use Data::Dumper;
 use Digest::SHA;
 use Carp;
 use Params::Validate qw(:all);
+use File::Path qw(make_path);
 use File::Spec;
 use IO::All;
 
@@ -417,9 +418,19 @@ sub init {
   my $desc      = $self->repo->{description} || "$component repository";
 
   my $repo_dir = $self->app->get_repo_dir( repo => $self->repo->{name} );
+  my @repodata_paths = (File::Spec->catdir($repo_dir,'dists',$dist,$component,"binary-$arch"),  File::Spec->catdir($repo_dir,'pool',$dist,$component));
 
-  File::Path->make_path(File::Spec->catdir($repo_dir,'dists',$dist,$component,"binary-$arch"));
-  File::Path->make_path(File::Spec->catdir($repo_dir,'pool',$dist,$component));
+  for my $repodata_path (@repodata_paths) {
+    $self->app->logger->debug("init: repodata_path: ${repodata_path}");
+    unless (-d $repodata_path) {
+      $self->app->logger->debug("init: make_path: ${repodata_path}");
+      my $make_path_error;
+      unless (make_path($repodata_path)) {
+        $self->app->logger->log_and_croak(level => 'error', message => "init: unable to create path: ${repodata_path}");
+      }
+    }
+  }
+
 
   my $aptftp      = io("$repo_dir/aptftp.conf");
   my $aptgenerate = io("$repo_dir/aptgenerate.conf");


### PR DESCRIPTION
When running `repositor --repo=reponame --init` as a non root user, I was getting the error

> mkdir File::Path: Permission denied at /usr/local/share/perl/5.20.2/Rex/Repositorio/Repository/Apt.pm line 421.

The `repositor` user had read/write permission on the `/var/www/repo directory`. The Yum repository initialization was working correctly. So I updated `Apt.pm` as per `Yum.pm`, and the error went away.

Fixes #49 