### PR TITLE
Replace rmtree, fix parameter passing

### DIFF
--- a/lib/Rex/Repositorio.pm
+++ b/lib/Rex/Repositorio.pm
@@ -15,7 +15,7 @@ use XML::LibXML;
 use XML::Simple;
 use Params::Validate qw(:all);
 use IO::All;
-use File::Path 'make_path';
+use File::Path 'make_path', 'remove_tree';
 use File::Basename qw'dirname';
 use File::Spec;
 use File::Copy;
@@ -450,7 +450,7 @@ sub tag {
   if ( -e $tag_dir ) {
     if( $option{force} ) {
       $self->logger->debug("Removing $tag_dir");
-      rmtree $tag_dir; # should be remove_tree, but will use legacy to match mkdir
+      remove_tree ( $tag_dir );
     }
     else {
       $self->logger->log_and_croak(level => 'error', message => "Tag $option{tag} on repo $option{repo} already exists (${tag_dir}), use --force\n");

--- a/lib/Rex/Repositorio/Repository/Apt.pm
+++ b/lib/Rex/Repositorio/Repository/Apt.pm
@@ -554,7 +554,7 @@ sub _run_ftp_archive {
 
     # export pub key as asc file
     my $pub_file = $self->repo->{name} . ".asc";
-    $cmd = "cd $repo_dir ; gpg -a --output $pub_file --export $key";
+    $cmd = "cd $repo_dir ; gpg -a --export $key > $pub_file";
     system $cmd;
 
     if ( $? != 0 ) {

--- a/lib/Rex/Repositorio/Repository/Apt.pm
+++ b/lib/Rex/Repositorio/Repository/Apt.pm
@@ -13,6 +13,7 @@ use Data::Dumper;
 use Digest::SHA;
 use Carp;
 use Params::Validate qw(:all);
+use File::Path qw(make_path);
 use File::Spec;
 use IO::All;
 
@@ -417,9 +418,19 @@ sub init {
   my $desc      = $self->repo->{description} || "$component repository";
 
   my $repo_dir = $self->app->get_repo_dir( repo => $self->repo->{name} );
+  my @repodata_paths = (File::Spec->catdir($repo_dir,'dists',$dist,$component,"binary-$arch"),  File::Spec->catdir($repo_dir,'pool',$dist,$component));
 
-  File::Path->make_path(File::Spec->catdir($repo_dir,'dists',$dist,$component,"binary-$arch"));
-  File::Path->make_path(File::Spec->catdir($repo_dir,'pool',$dist,$component));
+  for my $repodata_path (@repodata_paths) {
+    $self->app->logger->debug("init: repodata_path: ${repodata_path}");
+    unless (-d $repodata_path) {
+      $self->app->logger->debug("init: make_path: ${repodata_path}");
+      my $make_path_error;
+      unless (make_path($repodata_path)) {
+        $self->app->logger->log_and_croak(level => 'error', message => "init: unable to create path: ${repodata_path}");
+      }
+    }
+  }
+
 
   my $aptftp      = io("$repo_dir/aptftp.conf");
   my $aptgenerate = io("$repo_dir/aptgenerate.conf");


### PR DESCRIPTION
remove_tree is the modern (v2+) method for this, so replace rmtree with this.
Also fix it so that the parameter is passed correctly.
This resolves an issue with replacing tags.